### PR TITLE
Wave 3: migrate static hosting to AWS S3 + CloudFront

### DIFF
--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -1,0 +1,67 @@
+name: Deploy to AWS (S3 + CloudFront)
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: us-east-1
+  S3_BUCKET: gyanmarg-prod
+  CLOUDFRONT_DISTRIBUTION_ID: E1XLQPBNNEVOB8
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./app
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # package-lock is intentionally not used (Alpine rollup optional-deps issue) — matches app/Dockerfile
+      - run: npm install
+
+      - run: npm run build
+        env:
+          NODE_OPTIONS: --max-old-space-size=4096
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::405633560616:role/gha-gyanmarg-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      # Pass 1 — hashed/static assets, long cache; --delete removes stale, *.html protected by exclude.
+      - name: Sync assets (long cache)
+        run: |
+          aws s3 sync dist/ "s3://${S3_BUCKET}/" --delete \
+            --exclude "*.html" \
+            --cache-control "public,max-age=86400"
+
+      # Pass 2 — HTML only, no-cache so deploys are picked up immediately.
+      - name: Sync HTML (no cache)
+        run: |
+          aws s3 sync dist/ "s3://${S3_BUCKET}/" --delete \
+            --exclude "*" --include "*.html" \
+            --content-type "text/html; charset=utf-8" \
+            --cache-control "public,max-age=0,must-revalidate"
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" \
+            --paths "/*"


### PR DESCRIPTION
Adds deploy-aws.yml — builds the Vite SPA (app/) and publishes to AWS S3 + CloudFront (bucket gyanmarg-prod, dist E1XLQPBNNEVOB8), migrating gyanmarg's static-SPA hosting off GCP Cloud Run (CryptoPrism GCP->AWS Wave 3). Deploys via OIDC role gha-gyanmarg-deploy, reuses existing VITE_FIREBASE_* secrets, two-pass cache + CF invalidation (mirrors cryptoprism-app). Firestore + Firebase Auth unchanged (stay on Firebase); only the static host moves. Existing GCP deploy.yml left intact until cutover verified. Note: after first deploy, add the CloudFront origin to Firebase authorized redirect URIs for Google sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)